### PR TITLE
Fix using depricated functon String.rjust

### DIFF
--- a/posts/elixir/1/index.md
+++ b/posts/elixir/1/index.md
@@ -385,8 +385,8 @@ defimpl Inspect, for: Portal do
 
     """
     #Portal<
-      #{String.rjust(left_door, max)} <=> #{right_door}
-      #{String.rjust(left_data, max)} <=> #{right_data}
+      #{String.pad_leading(left_door, max)} <=> #{right_door}
+      #{String.pad_leading(left_data, max)} <=> #{right_data}
     >
     """
   end


### PR DESCRIPTION
String.rjust is deprecated. Using String.pad_leading is recommended.